### PR TITLE
Fix flopy version requirement for pyGSFLOW master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install flopy and pygsflow
       shell: bash -l {0}
       run: |
-        pip install https://github.com/modflowpy/flopy/zipball/develop
+        pip install flopy==3.3.4
         pip install .
 
     - name: Setup symbolic link to gfortran on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         cd ..
         pip install pytest
         pip install pytest-cov
-        pip install https://github.com/modflowpy/flopy/zipball/develop
+        pip install flopy==3.3.4
         pip install .
         pytest ./autotest/ --cov=gsflow --cov-report=xml
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('README.md') as readme_file:
 if sys.version_info >= (3, 0):
     requirements = ["pandas",
                     "numpy",
-                    "flopy >= 3.3.1",
+                    "flopy == 3.3.4",
                     "pyshp",
                     "pycrs",
                     "matplotlib"]


### PR DESCRIPTION
Flopy > 3.3.4 has deprecated parts of old code that cause the master branch to crash upon load.