### PR TITLE
Update pygsflow1.1.0_Builder_tutorial_09_land_cover_and_soils.ipynb

### DIFF
--- a/examples/pygsflow1.1.0_Builder_tutorial_09_land_cover_and_soils.ipynb
+++ b/examples/pygsflow1.1.0_Builder_tutorial_09_land_cover_and_soils.ipynb
@@ -616,7 +616,7 @@
     "\n",
     "# gravity reservoir routing coefficients\n",
     "ssr2gw_rate = bu.ssr2gw_rate(ksat, sand, soil_moist_max.values)\n",
-    "ssr2gw_sq = bu.ssr2gw_exp(ml.modelgrid.nnodes)\n",
+    "ssr2gw_sq = bu.ssr2gw_exp(int(ml.modelgrid.nnodes/ml.modelgrid.nlay))\n",
     "\n",
     "# slow flow gravity reservoir routing coefficients\n",
     "slowcoef_lin = bu.slowcoef_lin(ksat, hru_aspect.values, cellsize, cellsize)\n",


### PR DESCRIPTION
To make the code more comprehensive, nnodes need to be divided by nlay for multi-layered MODFLOW models.  Otherwise, prms parameter file will rise issue in loading stage at notebook #10. Moreover, nhru has to consider nlay for such a multi-layered case.