### PR TITLE
adding upslope function unittests and fixing PRMSDay write method

### DIFF
--- a/autotest/test_026.py
+++ b/autotest/test_026.py
@@ -1,0 +1,31 @@
+from gsflow import GsflowModel
+import os
+
+
+ws = os.path.abspath(os.path.dirname(__file__))
+model_ws = os.path.join(ws, "..", "examples", "data", "sagehen", "gsflow")
+control_file = os.path.join(model_ws, "saghen_new_cont.control")
+
+
+def test_upslope_neighbors():
+    gsf = GsflowModel.load_from_file(control_file)
+    params = gsf.prms.parameters
+    conn, pct = params.upslope_neighbors()
+    if not isinstance(conn, dict):
+        raise AssertionError()
+    if not isinstance(pct, dict):
+        raise AssertionError
+
+
+def test_upslope_neighbors_with_hru():
+    gsf = GsflowModel.load_from_file(control_file)
+    params = gsf.prms.parameters
+    conn, pct = params.upslope_neighbors(5267)
+    assert conn == [5351, 5352, 5350, 5266, 5182]
+    assert pct == [0.253, 0.017, 0.292, 0.192, 0.089]
+
+
+if __name__ == '__main__':
+    test_upslope_neighbors()
+    test_upslope_neighbors_with_hru()
+

--- a/autotest/test_027.py
+++ b/autotest/test_027.py
@@ -1,0 +1,41 @@
+import gsflow
+import os
+import pytest
+
+ws = os.path.abspath(os.path.dirname(__file__))
+model_ws = os.path.join("..", "examples", "data", "sagehen", "50m_tutorials")
+control = os.path.join(model_ws, "sagehen_50m_initial.control")
+
+
+def test_upslope_streams():
+    gsf = gsflow.GsflowModel.load_from_file(control)
+    params = gsf.prms.parameters
+    strms = params.upslope_streams()
+    if not isinstance(strms, dict):
+        raise AssertionError("Upslope_streams returned incorrect type")
+
+
+def test_upslope_streams_with_hru():
+    gsf = gsflow.GsflowModel.load_from_file(control)
+    params = gsf.prms.parameters
+    strms = params.upslope_streams(stream_hru=10787)
+    print(strms)
+    if not isinstance(strms, dict):
+        raise AssertionError("Upslope_streams returned incorrect type")
+    if not len(strms) == 41:
+        raise AssertionError("Upslope streams returned stream_conn_stack of incorrect length")
+    assert strms[10787] == [10935]
+
+
+def test_upslope_streams_no_cascades():
+    gsf = gsflow.GsflowModel.load_from_file(control)
+    params = gsf.prms.parameters
+    params.hru_strmseg_down_id[:] = 0
+    with pytest.raises(AssertionError):
+        params.upslope_streams()
+
+
+if __name__ == '__main__':
+    test_upslope_streams()
+    test_upslope_streams_with_hru()
+    test_upslope_streams_no_cascades()

--- a/autotest/test_027.py
+++ b/autotest/test_027.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 ws = os.path.abspath(os.path.dirname(__file__))
-model_ws = os.path.join("..", "examples", "data", "sagehen", "50m_tutorials")
+model_ws = os.path.join(ws, "..", "examples", "data", "sagehen", "50m_tutorials")
 control = os.path.join(model_ws, "sagehen_50m_initial.control")
 
 
@@ -19,7 +19,6 @@ def test_upslope_streams_with_hru():
     gsf = gsflow.GsflowModel.load_from_file(control)
     params = gsf.prms.parameters
     strms = params.upslope_streams(stream_hru=10787)
-    print(strms)
     if not isinstance(strms, dict):
         raise AssertionError("Upslope_streams returned incorrect type")
     if not len(strms) == 41:

--- a/examples/data/sagehen/50m_tutorials/sagehen_50m_initial.control
+++ b/examples/data/sagehen/50m_tutorials/sagehen_50m_initial.control
@@ -103,7 +103,7 @@ transp_tindex
 param_file
 1
 4
-data\sagehen\50m_tutorials\sagehen_50m_initial.param
+sagehen_50m_initial.param
 ####
 modflow_name
 1

--- a/gsflow/prms/prms_day.py
+++ b/gsflow/prms/prms_day.py
@@ -228,16 +228,24 @@ class PrmsDay(object):
                     f.write("orad 1\n")
 
                 f.write("#" * 40 + "\n")
-
-                df.to_csv(
-                    f,
-                    sep=" ",
-                    header=None,
-                    index=False,
-                    na_rep=-999,
-                    line_terminator="\n",
-                )
-
+                try:
+                    df.to_csv(
+                        f,
+                        sep=" ",
+                        header=None,
+                        index=False,
+                        na_rep=-999,
+                        lineterminator="\n",
+                    )
+                except:
+                    df.to_csv(
+                        f,
+                        sep=" ",
+                        header=None,
+                        index=False,
+                        na_rep=-999,
+                        line_terminator="\n",
+                    )
             del df
             self.__dataframe = None
 

--- a/gsflow/utils/sfr_renumber.py
+++ b/gsflow/utils/sfr_renumber.py
@@ -208,7 +208,7 @@ class SfrRenumber(object):
 
         if self.scheme in ("sfr", "dis"):
             # sort by topography
-            data = pd.DataFrame(columns=["segment", "elev"])
+            data = pd.DataFrame(columns=["segment", "elev"], dtype=float)
             sfr_ds2 = self.sfr.reach_data
 
             if self.scheme == "sfr":
@@ -220,7 +220,13 @@ class SfrRenumber(object):
                                 s2 = pd.Series(
                                     {"segment": iseg, "elev": strtop}
                                 )
-                                data = data.append(s2, ignore_index=True)
+                                try:
+                                    df_s2 = pd.DataFrame(s2).transpose()
+                                    data = pd.concat([data, df_s2],
+                                                     ignore_index=True,
+                                                     )
+                                except:
+                                    data = data.append(s2, ignore_index=True)
                                 break
 
             elif self.scheme == "dis":
@@ -235,7 +241,13 @@ class SfrRenumber(object):
                                 s2 = pd.Series(
                                     {"segment": iseg, "elev": strelev}
                                 )
-                                data = data.append(s2, ignore_index=True)
+                                try:
+                                    df_s2 = pd.DataFrame(s2).transpose()
+                                    data = pd.concat([data, df_s2],
+                                                     ignore_index=True,
+                                                     )
+                                except:
+                                    data = data.append(s2, ignore_index=True)
                                 break
 
             data = data.sort_values(by=["elev"], ascending=False)


### PR DESCRIPTION
I've added test_026.py and test_027.py test unslope_neighbors and upslope_streams respectively. Currently testing 

I've also added try/except logic to the PRMSDay class to catch backwards compatibility issues with pd.read_csv's lineterminator argument. This can be removed in future versions once line_terminator is deprecated.