### PR TITLE
fix: in ParameterRecord print newline when width is None

### DIFF
--- a/gsflow/prms/prms_parameter.py
+++ b/gsflow/prms/prms_parameter.py
@@ -814,6 +814,8 @@ class ParameterRecord(RecordBase):
         fid.write(" ")
         if self.width is not None:
             fid.write("{}\n".format(self.width))
+        else:
+            fid.write("\n")
         # write number of dimension
         fid.write(str(self.ndim))
         # write dimension names


### PR DESCRIPTION
If the width of a parameter is set to None, the number of dimensions is written at the end of the parameter name line.